### PR TITLE
Fix IndexOutOfBounds Exception when showing tab/panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Fixed
+- Fixed an exception which was occurring when the tab was shown during install.
 
 ## [1.2.0] - 2020-04-14
 

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
@@ -20,6 +20,7 @@ package org.zaproxy.zap.extension.neonmarker;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.EventQueue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -279,7 +280,7 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
     public void postInstall() {
         super.postInstall();
         if (getView() != null) {
-            getNeonmarkerPanel().setTabFocus();
+            EventQueue.invokeLater(() -> getNeonmarkerPanel().setTabFocus());
         }
     }
 }


### PR DESCRIPTION
- postInstall when extension panels/tabs are shown ensure it's done in EDT thus preventing the exception that was manifesting.
- Add a Fix entry to the CHANGELOG.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>