### PR TITLE
Add Build/Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Build Release
+
+on:
+  push:
+    tags: 
+      - '*'
+
+jobs:
+  build:
+    if: github.actor == 'kingthorin'
+    name: Build Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Gradle Build and Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew createReleaseFromGitHubRef

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,3 +53,34 @@ zapAddOn {
         }
     }
 }
+
+System.getenv("GITHUB_REF")?.let { ref ->
+    if ("refs/tags/" !in ref) {
+        return@let
+    }
+
+    tasks.register<CreateGitHubRelease>("createReleaseFromGitHubRef") {
+        val targetTag = ref.removePrefix("refs/tags/")
+        val targetAddOnVersion = targetTag.removePrefix("v")
+
+        authToken.set(System.getenv("GITHUB_TOKEN"))
+        repo.set(System.getenv("GITHUB_REPOSITORY"))
+        tag.set(targetTag)
+
+        title.set(provider { "Version ${zapAddOn.addOnVersion.get()}" })
+        bodyFile.set(tasks.named<ExtractLatestChangesFromChangelog>("extractLatestChanges").flatMap { it.latestChanges })
+
+        assets {
+            register("add-on") {
+                file.set(tasks.named<Jar>(AddOnPlugin.JAR_ZAP_ADD_ON_TASK_NAME).flatMap { it.archiveFile })
+            }
+        }
+
+        doFirst {
+            val addOnVersion = zapAddOn.addOnVersion.get()
+            require(addOnVersion == targetAddOnVersion) {
+                "Version of the tag $targetAddOnVersion does not match the version of the add-on $addOnVersion"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Uses Java 8 on ubuntu-latest

There's an example here:
- https://github.com/kingthorin/neon/runs/1179940511?check_suite_focus=true
- https://github.com/kingthorin/neon/releases/tag/v1.3.0 (Change Log details added manually)
<sub>The kingthorin/neon repo is temporary for testing/PoC.</sub>

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>