### PR TITLE
feat: Add arbitrary color support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Added
+- A right-click context menu is now available in the History tab in order to Select/Set a color for arbitrary messages.
 
 ## [1.4.0] - 2021-08-26
 

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
@@ -27,6 +27,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
+import javax.swing.ImageIcon;
 import org.apache.commons.lang3.Range;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,7 +52,6 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
     private static final Logger LOGGER = LogManager.getLogger(ExtensionNeonmarker.class);
     private static final Range<Integer> INT_RANGE =
             Range.between(Integer.MIN_VALUE, Integer.MAX_VALUE);
-    public static final String RESOURCE = "/org/zaproxy/zap/extension/neonmarker/resources";
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
 
     static {
@@ -61,11 +62,21 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionNeonmarker";
     public static final Color PLACEHOLDER = new Color(0, 0, 0, 0);
+    public static final String RESOURCE = "/org/zaproxy/zap/extension/neonmarker/resources";
+
+    public static final String TAG_PREFIX = "neon_";
+    public static final Pattern TAG_PATTERN =
+            Pattern.compile(
+                    ExtensionNeonmarker.TAG_PREFIX
+                            + "[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}");
     private ArrayList<ColorMapping> colormap;
     private NeonmarkerPanel neonmarkerPanel;
     private MarkItemColorHighlighter highlighter = null;
 
     private static List<Color> palette = null;
+    private static ImageIcon icon;
+
+    private PopupMenuHistoryNeonmarker menuHistoryColor;
 
     public ExtensionNeonmarker() {
         super(NAME);
@@ -76,10 +87,12 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
     public void hook(ExtensionHook extensionHook) {
         colormap = new ArrayList<>();
 
-        if (getView() != null) {
+        if (hasView()) {
             toggleHighlighter(true);
             extensionHook.getHookView().addWorkPanel(getNeonmarkerPanel());
             ExtensionHelp.enableHelpKey(getNeonmarkerPanel(), "neonmarker");
+
+            extensionHook.getHookMenu().addPopupMenuItem(getMenuHistoryColor());
         }
     }
 
@@ -139,11 +152,18 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
         return palette;
     }
 
-    private NeonmarkerPanel getNeonmarkerPanel() {
+    NeonmarkerPanel getNeonmarkerPanel() {
         if (neonmarkerPanel == null) {
             neonmarkerPanel = new NeonmarkerPanel(getHistoryExtension().getModel(), colormap);
         }
         return neonmarkerPanel;
+    }
+
+    static ImageIcon getIcon() {
+        if (icon == null) {
+            icon = new ImageIcon(ExtensionNeonmarker.class.getResource(RESOURCE + "/spectrum.png"));
+        }
+        return icon;
     }
 
     private ExtensionHistory getHistoryExtension() {
@@ -327,5 +347,12 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
         if (getView() != null) {
             EventQueue.invokeLater(() -> getNeonmarkerPanel().setTabFocus());
         }
+    }
+
+    private PopupMenuHistoryNeonmarker getMenuHistoryColor() {
+        if (menuHistoryColor == null) {
+            menuHistoryColor = new PopupMenuHistoryNeonmarker();
+        }
+        return menuHistoryColor;
     }
 }

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/PopupMenuHistoryNeonmarker.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/PopupMenuHistoryNeonmarker.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.neonmarker;
+
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
+import org.zaproxy.zap.view.popup.PopupMenuHistoryReferenceContainer;
+
+public class PopupMenuHistoryNeonmarker extends PopupMenuHistoryReferenceContainer {
+
+    private static final long serialVersionUID = 5126729231139965308L;
+
+    public PopupMenuHistoryNeonmarker() {
+        super(Constant.messages.getString("neonmarker.popup.label"), true);
+        setIcon(ExtensionNeonmarker.getIcon());
+        setButtonStateOverriddenByChildren(false);
+        PopupMenuItemHistoryColor setColor =
+                new PopupMenuItemHistoryColor(
+                        Constant.messages.getString("neonmarker.popup.item.color.label"));
+        PopupMenuItemHistoryUntag unTag =
+                new PopupMenuItemHistoryUntag(
+                        Constant.messages.getString("neonmarker.popup.item.untag.label"));
+        this.add(setColor);
+        this.add(unTag);
+    }
+
+    @Override
+    public boolean isEnableForInvoker(Invoker invoker, HttpMessageContainer httpMessageContainer) {
+        return (invoker == Invoker.HISTORY_PANEL);
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+
+    @Override
+    public boolean precedeWithSeparator() {
+        return true;
+    }
+}

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/PopupMenuItemHistoryColor.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/PopupMenuItemHistoryColor.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.neonmarker;
+
+import java.awt.Color;
+import java.util.List;
+import java.util.UUID;
+import javax.swing.JColorChooser;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.HistoryReference;
+import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
+
+public class PopupMenuItemHistoryColor extends PopupMenuItemHistoryReferenceContainer {
+
+    private static final long serialVersionUID = 2746419567363361343L;
+
+    private ExtensionNeonmarker extNeon =
+            Control.getSingleton().getExtensionLoader().getExtension(ExtensionNeonmarker.class);
+
+    public PopupMenuItemHistoryColor(String label) {
+        super(label, true);
+    }
+
+    @Override
+    public void performHistoryReferenceActions(List<HistoryReference> hrefs) {
+        Color newColor =
+                JColorChooser.showDialog(
+                        this,
+                        Constant.messages.getString("neonmarker.panel.color.chooser.title"),
+                        Color.WHITE);
+        String uuid = ExtensionNeonmarker.TAG_PREFIX + UUID.randomUUID().toString();
+        hrefs.forEach(hr -> hr.addTag(uuid));
+        extNeon.addColorMapping(uuid, newColor.getRGB());
+    }
+
+    @Override
+    protected void performAction(HistoryReference historyReference) {
+        // Nothing to do
+    }
+}

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/PopupMenuItemHistoryUntag.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/PopupMenuItemHistoryUntag.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.neonmarker;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.parosproxy.paros.model.HistoryReference;
+import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
+
+public class PopupMenuItemHistoryUntag extends PopupMenuItemHistoryReferenceContainer {
+
+    private static final long serialVersionUID = 2746419567363361343L;
+
+    public PopupMenuItemHistoryUntag(String label) {
+        super(label, true);
+    }
+
+    @Override
+    public void performHistoryReferenceActions(List<HistoryReference> hrefs) {
+        hrefs.forEach(
+                hr -> {
+                    List<String> tagsBeingKept =
+                            hr.getTags().stream()
+                                    .filter(
+                                            tag ->
+                                                    !ExtensionNeonmarker.TAG_PATTERN
+                                                            .matcher(tag)
+                                                            .matches())
+                                    .collect(Collectors.toList());
+                    hr.setTags(tagsBeingKept);
+                });
+    }
+
+    @Override
+    protected void performAction(HistoryReference historyReference) {
+        // Nothing to do.
+    }
+}

--- a/src/main/javahelp/help/contents/intro.html
+++ b/src/main/javahelp/help/contents/intro.html
@@ -10,6 +10,10 @@ Neonmarker
 <H1>Neonmarker</H1>
 Neonmarker addon, which colours History table entries based on tags.
 
+The add-on also facilitates colouring arbitrary messages in the History table via a right-click context menu. Tags are added to the selected messages to deliver the necessary colouring.
+Neonmarker's custom tags take the form <code>neon_UUID</code>, for example: <code>neon_e8b1d1e6-9dd4-4996-bc02-de2213986352</code>. Another context menu item provides functionality to 
+remove Neonmarker's custom tags.
+
 The following code example shows how to add a Neonmarker colorMapping via JavaScript within ZAP using a Stand Alone script.
 
 <code>extNeon = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension(org.zaproxy.zap.extension.neonmarker.ExtensionNeonmarker.NAME);

--- a/src/main/resources/org/zaproxy/zap/extension/neonmarker/resources/Messages.properties
+++ b/src/main/resources/org/zaproxy/zap/extension/neonmarker/resources/Messages.properties
@@ -1,14 +1,19 @@
 neonmarker.name = Neonmarker
 
 neonmarker.panel.title = Neonmarker
-neonmarker.panel.button.clear = Remove all rules
-neonmarker.panel.button.add = Add a rule
-neonmarker.panel.mapping.remove = Remove rule
-neonmarker.panel.mapping.move = Change precedence
-neonmarker.panel.mapping.notags = No tags available
+neonmarker.panel.button.clear = Remove All Rules
+neonmarker.panel.button.add = Add a Rule
+neonmarker.panel.mapping.remove = Remove Rule
+neonmarker.panel.mapping.move = Change Precedence
+neonmarker.panel.mapping.notags = No Tags Available
 neonmarker.panel.color.chooser.title = Choose Custom Color
 neonmarker.panel.color.menu.custom.label = Custom
 neonmarker.panel.toolbar.toggle.button.label.enabled = Enabled
 neonmarker.panel.toolbar.toggle.button.tooltip.enabled = Click to disable coloring rules.
 neonmarker.panel.toolbar.toggle.button.label.disabled = Disabled
 neonmarker.panel.toolbar.toggle.button.tooltip.disabled = Click to enable coloring rules.
+neonmarker.remove.prompt.title = Neonmarker
+neonmarker.remove.prompt.message = Remove Neonmarker's History Tags as well?\n\nYes - Remove color and tags. No - Remove color only. Cancel - Do nothing.
+neonmarker.popup.label = Neonmarker
+neonmarker.popup.item.color.label = Select/Set Color
+neonmarker.popup.item.untag.label = Un-Tag/Remove Color


### PR DESCRIPTION
- CHANGELOG > Add note.
- PopupMenuHistoryNeonMarker > The parent menu (item).
- PopupMenuItemHistoryColor > The menu item which facilitates coloring arbitrary messages in the history panel.
- PopupMenuItemHistoryUntag > A menu item to facilitate removing coloring/tags related to Neonmarker's coloring of arbitrary items.
- Messages.properties > Supporting key/values pairs and Issue 2000 tweaks.
- ExtensionNeonmarker > Hook the new menu.
- NeonmarkerPanel > Add a set for curly braces for consistency. Update remove button functionality.
- intro.html > Added description of the new functionality.
- Some constants were relocated and their visibility increased.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>