### PR TITLE
fix: show selection over neon row highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Changed
+- History row selection is shown over highlight colours.
 
 ## [1.8.0] - 2025-02-14
 ### Changed

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jdesktop.swingx.decorator.AbstractHighlighter;
 import org.jdesktop.swingx.decorator.ComponentAdapter;
-import org.jdesktop.swingx.decorator.HighlightPredicate;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.DatabaseException;
@@ -244,7 +243,7 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
 
         MarkItemColorHighlighter(ExtensionHistory extHistory, int idColumnIndex) {
             super();
-            setHighlightPredicate(HighlightPredicate.ALWAYS);
+            setHighlightPredicate((renderer, adapter) -> !adapter.isSelected());
             this.extHistory = extHistory;
             this.idColumnIndex = idColumnIndex;
         }


### PR DESCRIPTION
Skip neon background on selected History rows so table selection remains visible.