### PR TITLE
fix: use contrasting text on highlighted history rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - History row selection is shown over highlight colours.
+- Highlighted rows use contrasting text for readability.
 
 ## [1.8.0] - 2025-02-14
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,15 @@ zapAddOn {
 
 dependencies {
     compileOnly("org.zaproxy.addon:pscan:0.2.0")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:6.1.0")
+    testImplementation("org.hamcrest:hamcrest-library:3.0")
+
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 val projectInfo = ProjectInfo.from(project)

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/ExtensionNeonmarker.java
@@ -263,6 +263,7 @@ public class ExtensionNeonmarker extends ExtensionAdaptor {
             Color mark = mapTagsToColor(tags);
             if (mark != null) {
                 component.setBackground(mark);
+                component.setForeground(NeonmarkerColorUtils.contrastingForeground(mark));
             }
             return component;
         }

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/NeonmarkerColorUtils.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/NeonmarkerColorUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.neonmarker;
+
+import java.awt.Color;
+
+/** Color helpers for history row highlighting. */
+final class NeonmarkerColorUtils {
+
+    private NeonmarkerColorUtils() {}
+
+    /**
+     * Returns black or white so text remains readable on the given background.
+     *
+     * @param background the row background color
+     * @return a contrasting foreground color
+     */
+    static Color contrastingForeground(Color background) {
+        double luminance = relativeLuminance(background);
+        return luminance > 0.5 ? Color.BLACK : Color.WHITE;
+    }
+
+    private static double relativeLuminance(Color color) {
+        return (0.2126 * color.getRed() + 0.7152 * color.getGreen() + 0.0722 * color.getBlue())
+                / 255.0;
+    }
+}

--- a/src/test/java/org/zaproxy/zap/extension/neonmarker/NeonmarkerColorUtilsUnitTest.java
+++ b/src/test/java/org/zaproxy/zap/extension/neonmarker/NeonmarkerColorUtilsUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.neonmarker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.awt.Color;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link NeonmarkerColorUtils}. */
+class NeonmarkerColorUtilsUnitTest {
+
+    @Test
+    void shouldReturnBlackOnLightBackground() {
+        // Given / When
+        Color foreground = NeonmarkerColorUtils.contrastingForeground(Color.YELLOW);
+        // Then
+        assertThat(foreground, is(Color.BLACK));
+    }
+
+    @Test
+    void shouldReturnWhiteOnDarkBackground() {
+        // Given / When
+        Color foreground = NeonmarkerColorUtils.contrastingForeground(Color.BLUE);
+        // Then
+        assertThat(foreground, is(Color.WHITE));
+    }
+
+    @Test
+    void shouldReturnWhiteOnBlack() {
+        // Given / When
+        Color foreground = NeonmarkerColorUtils.contrastingForeground(Color.BLACK);
+        // Then
+        assertThat(foreground, is(Color.WHITE));
+    }
+}


### PR DESCRIPTION
Set foreground from background luminance so tag highlight colours remain readable.