### PR TITLE
fix: retain tag combobox selection on rule changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Tag combobox selection is retained when adding or reordering rules.
+
 ### Changed
 - History row selection is shown over highlight colours.
 - Highlighted rows use contrasting text for readability.

--- a/src/main/java/org/zaproxy/zap/extension/neonmarker/NeonmarkerPanel.java
+++ b/src/main/java/org/zaproxy/zap/extension/neonmarker/NeonmarkerPanel.java
@@ -305,6 +305,7 @@ class NeonmarkerPanel extends AbstractPanel {
 
     private Component getTagComboBox(ExtensionNeonmarker.ColorMapping rule) {
         TagListModel tagListModel = new TagListModel();
+        tagListModel.updateTags();
         JComboBox<String> tagSelect = new JComboBox<>(tagListModel);
         tagSelect.addPopupMenuListener(
                 new PopupMenuListener() {
@@ -323,12 +324,12 @@ class NeonmarkerPanel extends AbstractPanel {
                         // Nothing to do
                     }
                 });
+        tagSelect.setSelectedItem(rule.getTag());
         tagSelect.addActionListener(
                 actionEvent -> {
                     rule.setTag((String) tagSelect.getSelectedItem());
                     repaintHistoryTable();
                 });
-        tagSelect.setSelectedItem(rule.getTag());
         return tagSelect;
     }
 
@@ -440,9 +441,9 @@ class NeonmarkerPanel extends AbstractPanel {
 
         private void updateTags() {
             try {
-                allTags = historyTableModel.getDb().getTableTag().getAllTags();
+                allTags = new ArrayList<>(historyTableModel.getDb().getTableTag().getAllTags());
             } catch (Exception e) {
-                // do nothing
+                allTags = new ArrayList<>();
             }
             getExtension(ExtensionPassiveScan2.class).getAutoTaggingTags().stream()
                     .filter(e -> !allTags.contains(e))


### PR DESCRIPTION
Populate tags before setting the selected item and register the action listener after selection.